### PR TITLE
Update boundaries for latest TCA

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-        "version" : "1.0.0"
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "5da6989aae464f324eef5c5b52bdb7974725ab81",
-        "version" : "1.0.0"
+        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
+        "version" : "1.7.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "d1fd837326aa719bee979bdde1f53cd5797443eb",
-        "version" : "1.0.0"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "f62ba37cc0c51acb89f6dd1f552f6a1f9c58027c",
-        "version" : "1.1.0"
+        "revision" : "2d60d4082dfb4978974307acf0f00dfa20e5f621",
+        "version" : "1.22.3"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "ea631ce892687f5432a833312292b80db238186a",
-        "version" : "1.0.0"
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "edd66cace818e1b1c6f1b3349bb1d8e00d6f8b01",
-        "version" : "1.0.0"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "4e1eb6e28afe723286d8cc60611237ffbddba7c5",
-        "version" : "1.0.0"
+        "revision" : "a10f9feeb214bc72b5337b6ef6d5a029360db4cc",
+        "version" : "1.9.5"
       }
     },
     {
@@ -77,17 +77,44 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
-        "version" : "1.0.0"
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
       }
     },
     {
-      "identity" : "swiftui-navigation",
+      "identity" : "swift-navigation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "f5bcdac5b6bb3f826916b14705f37a3937c2fd34",
-        "version" : "1.0.0"
+        "revision" : "6b7f44d218e776bb7a5246efb940440d57c8b2cf",
+        "version" : "2.4.2"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "30721accd0370d7c9cb5bd0f7cdf5a1a767b383d",
+        "version" : "2.0.8"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
+        "version" : "2.7.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {
@@ -95,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
-        "version" : "1.0.2"
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/pointfreeco/swift-composable-architecture.git",
-            from: "1.1.0"
+            from: "1.22.3"
         ),
     ],
     targets: [

--- a/Sources/TCABoundaries/BoundedActions/Extensions/TCAFeatureAction+ForEachReducer.swift
+++ b/Sources/TCABoundaries/BoundedActions/Extensions/TCAFeatureAction+ForEachReducer.swift
@@ -22,7 +22,7 @@ extension Reducer where Action: TCAFeatureAction {
     ///     Reduce { state, action in
     ///       // Core logic for parent feature
     ///     }
-    ///     .forEach(\.rows, action: /Action.row) {
+    ///     .forEach(\.rows, action: \.row) {
     ///       Row()
     ///     }
     ///   }
@@ -55,14 +55,14 @@ extension Reducer where Action: TCAFeatureAction {
     @warn_unqualified_access
     public func forEach<ElementState, ElementAction, ID: Hashable, Element: Reducer>(
       _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
-      action toElementAction: CasePath<Action.InternalAction, (ID, ElementAction)>,
+      action toElementAction: CaseKeyPath<Action.InternalAction, (ID, ElementAction)>,
       @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
       fileID: StaticString = #fileID,
       line: UInt = #line
     ) -> _ForEachReducer<Self, ID, Element> where ElementState == Element.State, ElementAction == Element.Action {
         self.forEach(
             toElementsState,
-            action: (/Action._internal).appending(path: toElementAction),
+            action: (\Action.Cases._internal).appending(path: toElementAction),
             element: element,
             fileID: fileID,
             line: line

--- a/Sources/TCABoundaries/BoundedActions/Extensions/TCAFeatureAction+IfLetReducer.swift
+++ b/Sources/TCABoundaries/BoundedActions/Extensions/TCAFeatureAction+IfLetReducer.swift
@@ -21,7 +21,7 @@ extension Reducer where Action: TCAFeatureAction {
     ///     Reduce { state, action in
     ///       // Core logic for parent feature
     ///     }
-    ///     .ifLet(\.child, action: /Action.child) {
+    ///     .ifLet(\.child, action: \.child) {
     ///       Child()
     ///     }
     ///   }
@@ -55,14 +55,14 @@ extension Reducer where Action: TCAFeatureAction {
     @warn_unqualified_access
     public func ifLet<WrappedState, WrappedAction, Wrapped: Reducer>(
       _ toWrappedState: WritableKeyPath<State, WrappedState?>,
-      action toWrappedAction: CasePath<Action.InternalAction, WrappedAction>,
+      action toWrappedAction: CaseKeyPath<Action.InternalAction, WrappedAction>,
       @ReducerBuilder<WrappedState, WrappedAction> then wrapped: () -> Wrapped,
       fileID: StaticString = #fileID,
       line: UInt = #line
     ) -> _IfLetReducer<Self, Wrapped> where WrappedState == Wrapped.State, WrappedAction == Wrapped.Action {
         self.ifLet(
             toWrappedState,
-            action: (/Action._internal).appending(path: toWrappedAction),
+            action: (\Action.Cases._internal).appending(path: toWrappedAction),
             then: wrapped,
             fileID: fileID,
             line: line
@@ -73,13 +73,13 @@ extension Reducer where Action: TCAFeatureAction {
     @warn_unqualified_access
     public func ifLet<WrappedState: _EphemeralState, WrappedAction>(
         _ toWrappedState: WritableKeyPath<State, WrappedState?>,
-        action toWrappedAction: CasePath<Action.InternalAction, WrappedAction>,
+        action toWrappedAction: CaseKeyPath<Action.InternalAction, WrappedAction>,
         fileID: StaticString = #fileID,
         line: UInt = #line
     ) -> _IfLetReducer<Self, EmptyReducer<WrappedState, WrappedAction>> {
         self.ifLet(
             toWrappedState,
-            action: (/Action._internal).appending(path: toWrappedAction),
+            action: (\Action.Cases._internal).appending(path: toWrappedAction),
             fileID: fileID,
             line: line
         )

--- a/Sources/TCABoundaries/BoundedActions/Extensions/TCAFeatureAction+Scope.swift
+++ b/Sources/TCABoundaries/BoundedActions/Extensions/TCAFeatureAction+Scope.swift
@@ -17,29 +17,29 @@ extension Scope where ParentAction: TCAFeatureAction {
     /// ```
     /// Without this extension we would have to write something like:
     /// ```swift
-    /// Scope(/Action._internal .. /Action.InternalAction.child) {
+    /// Scope(\Action.Cases._internal.child) {
     ///    ChildFeature()
     /// }
     /// ```
     /// With this extension we are able to get a cleaner API like below:
     /// ```swift
-    /// Scope(state: \.child, action: /Action.InternalAction.child) {
+    /// Scope(state: \.child, action: \ParentAction.Cases._internal.child) {
     ///     ChildFeature()
     /// }
     /// ```
     /// - Parameters:
-    ///   - state: A function that transforms `State` into `ChildState`.
-    ///   - action: A function that transforms `Action.InternalAction` into `ChildAction`.
+    ///   - state: A key path that transforms `State` into `ChildState`.
+    ///   - action: A case key path that transforms `Action.InternalAction` into `ChildAction`.
     ///   - child: The reducer builder for the Child.
     @inlinable
     public init(
       state toChildState: WritableKeyPath<ParentState, Child.State>,
-      action toChildAction: CasePath<ParentAction.InternalAction, Child.Action>,
+      action toChildAction: CaseKeyPath<ParentAction.InternalAction, Child.Action>,
       _ child: () -> Child
     ) {
         self = .init(
             state: toChildState,
-            action: (/ParentAction._internal).appending(path: toChildAction),
+            action: (\ParentAction.Cases._internal).appending(path: toChildAction),
             child: child
         )
     }
@@ -51,10 +51,10 @@ extension Scope where ParentAction: TCAFeatureAction {
     ///
     /// ```swift
     /// var body: some Reducer<State, Action> {
-    ///   Scope(state: \.profile, action: /Action.profile) {
+    ///   Scope(state: \.profile, action: \.profile) {
     ///     Profile()
     ///   }
-    ///   Scope(state: \.settings, action: /Action.settings) {
+    ///   Scope(state: \.settings, action: \.settings) {
     ///     Settings()
     ///   }
     ///   // ...
@@ -68,12 +68,12 @@ extension Scope where ParentAction: TCAFeatureAction {
     @inlinable
     public init<ChildState, ChildAction>(
       state toChildState: WritableKeyPath<ParentState, ChildState>,
-      action toChildAction: CasePath<ParentAction.InternalAction, ChildAction>,
+      action toChildAction: CaseKeyPath<ParentAction.InternalAction, ChildAction>,
       @ReducerBuilder<ChildState, ChildAction> child: () -> Child
     ) where ChildState == Child.State, ChildAction == Child.Action {
       self.init(
         state: toChildState,
-        action: (/ParentAction._internal).appending(path: toChildAction),
+        action: (\ParentAction.Cases._internal).appending(path: toChildAction),
         child: child
       )
     }
@@ -85,10 +85,10 @@ extension Scope where ParentAction: TCAFeatureAction {
     ///
     /// ```swift
     /// var body: some Reducer<State, Action> {
-    ///   Scope(state: /State.loggedIn, action: /Action.loggedIn) {
+    ///   Scope(state: \.loggedIn, action: \.loggedIn) {
     ///     LoggedIn()
     ///   }
-    ///   Scope(state: /State.loggedOut, action: /Action.loggedOut) {
+    ///   Scope(state: \.loggedOut, action: \.loggedOut) {
     ///     LoggedOut()
     ///   }
     /// }
@@ -111,7 +111,7 @@ extension Scope where ParentAction: TCAFeatureAction {
     /// >   // ...
     /// >   }
     /// > }
-    /// > Scope(state: /State.loggedIn, action: /Action.loggedIn) {
+    /// > Scope(state: \.loggedIn, action: \.loggedIn) {
     /// >   LoggedIn()  // ⚠️ Logged-in domain can't handle `quitButtonTapped`
     /// > }
     /// > ```
@@ -128,7 +128,7 @@ extension Scope where ParentAction: TCAFeatureAction {
     /// >   // ...
     /// >   }
     /// > }
-    /// > .ifCaseLet(/State.loggedIn, action: /Action.loggedIn) {
+    /// > .ifCaseLet(\.loggedIn, action: \.loggedIn) {
     /// >   LoggedIn()  // ✅ Receives actions before its case can change
     /// > }
     /// > ```
@@ -139,15 +139,15 @@ extension Scope where ParentAction: TCAFeatureAction {
     ///   - child: A reducer that will be invoked with child actions against child state.
     @inlinable
     public init<ChildState, ChildAction>(
-      state toChildState: CasePath<ParentState, ChildState>,
-      action toChildAction: CasePath<ParentAction.InternalAction, ChildAction>,
+      state toChildState: CaseKeyPath<ParentState, ChildState>,
+      action toChildAction: CaseKeyPath<ParentAction.InternalAction, ChildAction>,
       @ReducerBuilder<ChildState, ChildAction> child: () -> Child,
       fileID: StaticString = #fileID,
       line: UInt = #line
     ) where ChildState == Child.State, ChildAction == Child.Action {
       self.init(
         state: toChildState,
-        action: (/ParentAction._internal).appending(path: toChildAction),
+        action: (\ParentAction.Cases._internal).appending(path: toChildAction),
         child: child,
         fileID: fileID,
         line: line

--- a/Sources/TCABoundaries/BoundedActions/Extensions/TCAFeatureAction+Store.swift
+++ b/Sources/TCABoundaries/BoundedActions/Extensions/TCAFeatureAction+Store.swift
@@ -1,3 +1,4 @@
+import CasePaths
 import ComposableArchitecture
 
 /// `ViewOnlyStoreOf` For use when scoping down to a store of only `ViewAction`
@@ -9,7 +10,7 @@ public typealias RestrictedViewStore<R: BoundingReducer> = ViewStore<R.State, R.
 extension Store where Action: TCAFeatureAction {
     /// Convenience var to quickly scope a store to just it's `ViewAction`
     public var viewScope: Store<State, Action.ViewAction> {
-        scope(state: { $0 }, action: Action.view)
+        scope(state: \.self, action: \.view)
     }
     /// When you have a `Child` flow inside a `Parent` store and need to scope it is often expressed as an `InternalAction` of the `Parent` store.
     /// This can lead to a bit a an awkward API when trying to express that relation...
@@ -34,7 +35,7 @@ extension Store where Action: TCAFeatureAction {
     ///         ChildView(
     ///             store.scope(
     ///                 state: \.childState,
-    ///                 action: (/ParentAction._internal .. /ParentAction.InternalAction.child).embed
+    ///                 action: \ParentAction.Cases._internal.child
     ///             )
     ///         )
     ///         // ...
@@ -50,7 +51,7 @@ extension Store where Action: TCAFeatureAction {
     ///         ChildView(
     ///             store.scope(
     ///                 state: \.childState,
-    ///                 action: /ParentAction.InternalAction.child
+    ///                 action: \ParentAction.Cases._internal.child
     ///             )
     ///         )
     ///         // ...
@@ -58,16 +59,16 @@ extension Store where Action: TCAFeatureAction {
     /// }
     /// ```
     /// - Parameters:
-    ///   - toChildState: A function that transforms `State` into `ChildState`.
-    ///   - fromChildAction: A function that transforms `Action.InternalAction` into `ChildAction`.
+    ///   - toChildState: A key path that transforms `State` into `ChildState`.
+    ///   - toChildAction: A case key path that transforms `Action.InternalAction` into `ChildAction`.
     /// - Returns: A new store with its domain (state and action) transformed.
     public func scope<ChildState, ChildAction>(
-        state toChildState: @escaping (State) -> ChildState,
-        action fromChildAction: CasePath<Action.InternalAction, ChildAction>
+        state toChildState: KeyPath<State, ChildState>,
+        action toChildAction: CaseKeyPath<Action.InternalAction, ChildAction>
     ) -> Store<ChildState, ChildAction> {
         scope(
             state: toChildState,
-            action: { ._internal(fromChildAction.embed($0)) }
+            action: (\Action.Cases._internal).appending(path: toChildAction)
         )
     }
 }

--- a/Sources/TCABoundaries/BoundedActions/TCAFeatureAction.swift
+++ b/Sources/TCABoundaries/BoundedActions/TCAFeatureAction.swift
@@ -1,3 +1,4 @@
+import CasePaths
 import Foundation
 
 /// The `TCAFeatureAction` defines a pattern for actions on TCA based on https://www.merowing.info/boundries-in-tca/
@@ -23,7 +24,12 @@ import Foundation
 ///     case _internal(InternalAction)
 /// }
 /// ```
-public protocol TCAFeatureAction: Equatable {
+///
+/// Conforming types should leverage support from ``CasePathable`` (for example by annotating the
+/// reducer with ``Reducer()`` or the action enum with ``CasePathable``) so that case key paths can
+/// be composed ergonomically when interacting with the latest versions of the Composable
+/// Architecture.
+public protocol TCAFeatureAction: CasePathable, Equatable {
     /// `ViewAction` relates  to actions that happen arround the view, being sent or received by it
     associatedtype ViewAction: Equatable
     /// `DelegateAction` relates to actions that are delegate to parent components (like the well known Delegate pattern)

--- a/Sources/TCABoundaries/BoundedReducers/BoundingReducer.swift
+++ b/Sources/TCABoundaries/BoundedReducers/BoundingReducer.swift
@@ -32,15 +32,15 @@ public extension BoundingReducer {
 
 public extension BoundingReducer where Body == Never {
     func reduce(into state: inout State, action: Action) -> Effect<Action> {
-        if let viewAction = (/Action.view).extract(from: action) {
+        if let viewAction = action[case: \.view] {
             return reduce(into: &state, viewAction: viewAction)
         }
-        
-        if let internalAction = (/Action._internal).extract(from: action) {
+
+        if let internalAction = action[case: \._internal] {
             return reduce(into: &state, internalAction: internalAction)
         }
-        
-        if let delegateAction = (/Action.delegate).extract(from: action) {
+
+        if let delegateAction = action[case: \.delegate] {
             return reduce(into: &state, delegateAction: delegateAction)
         }
         

--- a/Sources/TCABoundaries/BoundedReducers/ComposedBoundedReducer.swift
+++ b/Sources/TCABoundaries/BoundedReducers/ComposedBoundedReducer.swift
@@ -7,13 +7,13 @@ public protocol ComposedBoundingReducer: BoundingReducer {
 
 public extension ComposedBoundingReducer {
     func reduceCore(into state: inout State, action: Action) -> Effect<Action> {
-        if let action = (/Action.view).extract(from: action) {
+        if let action = action[case: \.view] {
             return reduce(into: &state, viewAction: action)
         }
-        if let action = (/Action._internal).extract(from: action) {
+        if let action = action[case: \._internal] {
             return reduce(into: &state, internalAction: action)
         }
-        if let action = (/Action.delegate).extract(from: action) {
+        if let action = action[case: \.delegate] {
             return reduce(into: &state, delegateAction: action)
         }
         return .none


### PR DESCRIPTION
## Summary
- raise the TCA dependency to 1.22.3 and adopt Swift tools 5.9
- make `TCAFeatureAction` leverage `CasePathable` so modern case key path APIs are available
- update the reducer helpers and store/scope extensions to work with case key paths and refreshed documentation examples

## Testing
- swift build *(fails: ComposableArchitecture now imports Combine, which is unavailable in the Linux container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2b435db88329a3067a898a92f044